### PR TITLE
Enable Solidity syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Simply allows for syntax highlighting of *.sol files when viewing in GitHub.  @michalmikolajczyk 