### PR TITLE
Fixes and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ atlassian-ide-plugin.xml
 
 # Cursive Clojure plugin
 .idea/replstate.xml
+.idea
 
 # Ruby plugin and RubyMine
 /.rakeTasks

--- a/contracts/Machine.sol
+++ b/contracts/Machine.sol
@@ -1,24 +1,25 @@
 pragma solidity ^0.4.18;
-import "../node_modules/zeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
-import "../node_modules/zeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+
+import "zeppelin-solidity/contracts/token/ERC20/ERC20Basic.sol";
+import "zeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
+import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+
 
 /**
  * @title Ownable
  * @dev The Ownable contract has an owner address, and provides basic authorization control
  * functions, this simplifies the implementation of "user permissions".
  */
-contract Machine {
+contract Machine is Ownable {
   using SafeERC20 for ERC20Basic;
 
-  address public owner;
   address public pendingRenter;
   address public renter;
   string public model;
   string public make;
-  bytes32 public vin;
+  bytes32 public id;
   uint256 public rentalPrice;
   uint256 public rentalCount;
-    // ERC20 basic token contract being held
   ERC20Basic public token;
 
   event MachineRental(address indexed _machine, address indexed _owner, address indexed _renter, uint256 startTime, uint256 endTime, uint256 _rentalPrice);
@@ -28,22 +29,15 @@ contract Machine {
 
   /**
    * @dev The MachineRepresentation constructor sets the original `owner` of the contract to the sender
-   * account. It also sets the model, make and VIN of the machine.
+   * account. It also sets the model, make and id of the machine.
    */
-  function Machine(string _model, string _make, bytes32 _vin) public {
-    owner = msg.sender;
+  function Machine(ERC20Basic _token, string _model, string _make, bytes32 _id) public
+  {
+    token = _token;
     model = _model;
     make = _make;
-    vin = _vin;
+    id = _validateId(_id);
     rentalCount = 0;
-  }
-
-  /**
-   * @dev Throws if called by any account other than the owner.
-   */
-  modifier onlyOwner() {
-    require(msg.sender == owner);
-    _;
   }
 
   /**
@@ -66,19 +60,19 @@ contract Machine {
    * @dev Allows the owner to rent out the machine to the renter, and specify the start and end time
    * and also the price for the rental
    */
-  function rentMachine(address _pendingRenter, uint256 startTime, uint256 endTime, uint256 price) public onlyOwner {
+  function rentMachine(address _pendingRenter, uint256 _startTime, uint256 _endTime, uint256 _price) public onlyOwner {
     require(_pendingRenter != address(0));
-    rentalPrice = price;
-    MachineRental(this, owner, _pendingRenter, startTime, endTime, price);
+    require(now <= _startTime && now <= _endTime && _startTime <= _endTime);
+    rentalPrice = _price;
     pendingRenter = _pendingRenter;
+    MachineRental(this, owner, _pendingRenter, _startTime, _endTime, _price);
   }
 
   /**
    * @dev Allows the pendingRenter address to finalize the transfer and provide a token contract, with the cash to hold
    */
-  function claimRental(ERC20Basic _token) onlyPendingRenter public {
-    require(rentalPrice <= _token.balanceOf(this));
-    token = _token;
+  function claimRental() onlyPendingRenter public {
+    require(rentalPrice <= token.balanceOf(pendingRenter));
     renter = pendingRenter;
     pendingRenter = address(0);
     RentalClaimed(this, renter, now);
@@ -102,5 +96,12 @@ contract Machine {
     rentalPrice = 0;
     rentalCount++;
     ReturnConfirmed(this, owner, now);
+  }
+
+  /**
+   * @dev Can be overridden to create a validation rule for ID
+   */
+  function _validateId(bytes32 _id) internal pure returns(bytes32) {
+    return _id;
   }
 }

--- a/contracts/MachineOwner.sol
+++ b/contracts/MachineOwner.sol
@@ -1,28 +1,18 @@
 pragma solidity ^0.4.18;
 
-import './Machine.sol';
+import "./Machine.sol";
 
-contract MachineOwner {
-  address public owner;
+
+contract MachineOwner is Ownable {
+
   mapping(bytes32 => address) public machines;
 
   event NewMachineAdded(address indexed newMachine, uint256 timestamp);
 
-  function MachineOwner() public {
-    owner = msg.sender;
-  }
-
-  /**
-   * @dev Throws if called by any account other than the owner.
-   */
-  modifier onlyOwner() {
-    require(msg.sender == owner);
-    _;
-  }
-
-  function createNewMachine(string model, string make, bytes32 vin) public onlyOwner {
-    address newMachine = new Machine(model, make, vin);
-    machines[vin] = newMachine;
+  function createNewMachine(ERC20Basic _token, string _model, string _make, bytes32 _id) public onlyOwner {
+    Machine newMachine = new Machine(_token, _model, _make, _id);
+    newMachine.transferOwnership(owner); // the contract should not be a owner of a new machine
+    machines[_id] = newMachine;
     NewMachineAdded(newMachine, now);
   }
 }

--- a/contracts/MachineToken.sol
+++ b/contracts/MachineToken.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.4.18;
+
+import "zeppelin-solidity/contracts/token/ERC20/BasicToken.sol";
+
+
+/**
+ * @dev An example token which can be used as a token in Machine
+ */
+
+
+contract MachineToken is BasicToken {
+
+  string private constant NAME = "Machine Token";
+  string private constant SYMBOL = "MCT";
+  uint256 private constant DECIMAL = 18;
+  uint256 private constant TOTAL_SUPPLY = 10 ** (DECIMAL + 10);
+
+  function MachineToken() public {
+    totalSupply_ = TOTAL_SUPPLY;
+    balances[msg.sender] = TOTAL_SUPPLY;
+  }
+}


### PR DESCRIPTION
- A token is passed in the constructor of Machine now
- Renamed vin to id (to be more generic) [Machine]
- Changed id type to bytes32 [Machine]
- Added a id validator, which can be overriden in subcontracts [Machine]
- Added time validation in rentMachine [Machine]
- Changed token.balanceOf(this)) to token.balanceOf(pendingRenter) [Machine]
- Added MachineToken - an example implementation of token for MachineOwner

Fixes #xx (insert issue number in place of `xx`)

Changes proposed in this pull request:
- …
- …

@michalmikolajczyk
